### PR TITLE
Migrate to use Android Gradle Plugin 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
-        mavenCentral()
+        google()
+        jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.7.+'
+        classpath 'com.android.tools.build:gradle:3.0.0'
     }
 }
 
@@ -17,7 +18,8 @@ allprojects {
     group = GROUP
 
     repositories {
-        mavenCentral()
+        google()
+        jcenter()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,8 +1,7 @@
-apply plugin: 'android-library'
+apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion '19.0.0'
 
     sourceSets {
         main {
@@ -13,4 +12,5 @@ android {
     }
 }
 
-apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/eaa6b5404b7594e6c23b884fdc5795f545db55dd/gradle-mvn-push.gradle'
+// TODO: Pointing to PR https://github.com/chrisbanes/gradle-mvn-push/pull/35 - Not Tested
+apply from: 'https://raw.githubusercontent.com/jpardogo/gradle-mvn-push/554fe61b782ae494d080513490cc68ce3919f7da/gradle-mvn-push.gradle'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,8 +1,5 @@
 apply plugin: 'android'
 
-repositories {
-    mavenCentral()
-}
 dependencies {
     compile project(':library')
     compile 'com.android.support:support-v4:18.0.0'
@@ -10,7 +7,6 @@ dependencies {
 
 android {
     compileSdkVersion 18
-    buildToolsVersion '18.0.1'
 
     sourceSets {
         main {


### PR DESCRIPTION
Note: gradle-mvn-push plugin was updated to a pending PR, it has not been
tested.